### PR TITLE
feat: use location if catalog url is not set

### DIFF
--- a/console-rs/src/lib.rs
+++ b/console-rs/src/lib.rs
@@ -19,7 +19,7 @@ pub struct LakekeeperConsoleConfig {
     pub idp_post_logout_redirect_path: String,
     pub enable_authentication: bool,
     pub enable_permissions: bool,
-    pub app_iceberg_catalog_url: String,
+    pub app_iceberg_catalog_url: Option<String>,
 }
 
 pub fn get_file(
@@ -57,13 +57,17 @@ pub fn get_file(
                     &enable_authentication.to_string(),
                 )
                 .replace(
-                    "VITE_APP_ICEBERG_CATALOG_URL_PLACEHOLDER",
-                    &app_iceberg_catalog_url,
-                )
-                .replace(
                     "VITE_ENABLE_PERMISSIONS_PLACEHOLDER",
                     &enable_permissions.to_string(),
                 );
+            let data = if let Some(app_iceberg_catalog_url) = app_iceberg_catalog_url {
+                data.replace(
+                    "VITE_APP_ICEBERG_CATALOG_URL_PLACEHOLDER",
+                    &app_iceberg_catalog_url,
+                )
+            } else {
+                data
+            };
 
             file.data = data.into_bytes().into();
             file
@@ -102,7 +106,7 @@ mod tests {
             idp_post_logout_redirect_path: "/logout-test".to_string(),
             enable_authentication: true,
             enable_permissions: false,
-            app_iceberg_catalog_url: "https://catalog.example.com".to_string(),
+            app_iceberg_catalog_url: Some("https://catalog.example.com".to_string()),
         };
         let files = LakekeeperConsole::iter().collect::<Vec<_>>();
 
@@ -113,7 +117,7 @@ mod tests {
             &config.idp_scope,
             &config.idp_resource,
             &config.idp_post_logout_redirect_path,
-            &config.app_iceberg_catalog_url,
+            config.app_iceberg_catalog_url.as_ref().unwrap(),
         ];
 
         let mut found_values = vec![false; config_values.len()];

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -1,5 +1,4 @@
 const icebergCatalogUrl = import.meta.env.VITE_APP_ICEBERG_CATALOG_URL || '';
-const icebergCatalogUrlSuffixed = import.meta.env.VITE_APP_ICEBERG_CATALOG_URL + '/catalog/' || '';
 const idpAuthority = import.meta.env.VITE_IDP_AUTHORITY || '';
 const idpClientId = import.meta.env.VITE_IDP_CLIENT_ID || '';
 const idpRedirectPath = import.meta.env.VITE_IDP_REDIRECT_PATH || '';
@@ -13,7 +12,6 @@ const enabledPermissions =
 
 export {
   icebergCatalogUrl,
-  icebergCatalogUrlSuffixed,
   idpAuthority,
   idpClientId,
   idpRedirectPath,

--- a/src/components/ComputeConnectDialog.vue
+++ b/src/components/ComputeConnectDialog.vue
@@ -144,8 +144,7 @@
 </template>
 
 <script lang="ts" setup>
-import * as env from '@/app.config';
-import { icebergCatalogUrlSuffixed, idpAuthority } from '@/app.config';
+import { idpAuthority } from '@/app.config';
 import { Type, User } from '@/common/interfaces';
 import { GetWarehouseResponse, S3Profile } from '@/gen/management';
 import { useAuth } from '@/plugins/auth';
@@ -264,7 +263,7 @@ config = {
     "spark.sql.defaultCatalog": "${props.warehouse.name}",
     "spark.sql.catalog.${props.warehouse.name}": "org.apache.iceberg.spark.SparkCatalog",
     "spark.sql.catalog.${props.warehouse.name}.type": "rest",
-    "spark.sql.catalog.${props.warehouse.name}.uri": "${icebergCatalogUrlSuffixed}",
+    "spark.sql.catalog.${props.warehouse.name}.uri": "${functions.icebergCatalogUrlSuffixed()}",
     "spark.sql.catalog.${props.warehouse.name}.warehouse": "${props.warehouse.name}",
     ${enabledAuthentication ? `"spark.sql.catalog.${props.warehouse.name}.token": "${user.access_token}",` : '##'}
     "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
@@ -289,7 +288,7 @@ conf = {
     "spark.sql.extensions": "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions",
     "spark.sql.catalog.${props.warehouse.name}": "org.apache.iceberg.spark.SparkCatalog",
     "spark.sql.catalog.${props.warehouse.name}.type": "rest",
-    "spark.sql.catalog.${props.warehouse.name}.uri": "${icebergCatalogUrlSuffixed}",
+    "spark.sql.catalog.${props.warehouse.name}.uri": "${functions.icebergCatalogUrlSuffixed()}",
     ${enabledAuthentication ? `"spark.sql.catalog.${props.warehouse.name}.credential": f"{CLIENT_ID}:{CLIENT_SECRET}",` : '##'}
     "spark.sql.catalog.${props.warehouse.name}.warehouse": "${props.warehouse.name}",
     "spark.sql.catalog.${props.warehouse.name}.scope": "lakekeeper",
@@ -310,7 +309,7 @@ from pyiceberg.catalog.rest import RestCatalog
 catalog = RestCatalog(
     name="${props.warehouse.name}",
     warehouse="${props.warehouse.name}",
-    uri="${icebergCatalogUrlSuffixed}",
+    uri="${functions.icebergCatalogUrlSuffixed()}",
     ${enabledAuthentication ? `token="${user.access_token}",` : '##'}
 )`;
       connectionStringHumanFlow.value = connectionStringHumanFlow.value
@@ -327,7 +326,7 @@ CLIENT_SECRET = "<ENTER YOUR CLIENT_SECRET HERE>"
 catalog = RestCatalog(
     name="${props.warehouse.name}",
     warehouse="${props.warehouse.name}",
-    uri="${icebergCatalogUrlSuffixed}",
+    uri="${functions.icebergCatalogUrlSuffixed()}",
     ${enabledAuthentication ? `credential=f"{CLIENT_ID}:{CLIENT_SECRET}",` : '##'}
     **{"rest.authorization-url": "${tokenEndpoint}", "scope": "lakekeeper"},
 )`;
@@ -387,7 +386,7 @@ cursor = conn.cursor();
 cursor.execute(f"""CREATE CATALOG ${props.warehouse.name} USING iceberg
 WITH (
 "iceberg.catalog.type" = 'rest',
-"iceberg.rest-catalog.uri" = '${env.icebergCatalogUrlSuffixed}',
+"iceberg.rest-catalog.uri" = '${functions.icebergCatalogUrlSuffixed()}',
 "iceberg.rest-catalog.warehouse" = '${visuals.projectSelected['project-id']}/${props.warehouse.name}',
 "iceberg.rest-catalog.security" = 'OAUTH2',
 "iceberg.rest-catalog.nested-namespace-enabled" = 'true',
@@ -427,7 +426,7 @@ cursor = conn.cursor();
 cursor.execute(f"""CREATE CATALOG ${props.warehouse.name} USING iceberg
 WITH (
 "iceberg.catalog.type" = 'rest',
-"iceberg.rest-catalog.uri" = '${env.icebergCatalogUrlSuffixed}',
+"iceberg.rest-catalog.uri" = '${functions.icebergCatalogUrlSuffixed()}',
 "iceberg.rest-catalog.warehouse" = '${visuals.projectSelected['project-id']}/${props.warehouse.name}',
 "iceberg.rest-catalog.security" = 'OAUTH2',
 ${enabledAuthentication ? `"iceberg.rest-catalog.oauth2.credential" = '{CLIENT_ID}:{CLIENT_SECRET}',` : '##'}

--- a/src/plugins/functions.ts
+++ b/src/plugins/functions.ts
@@ -58,7 +58,7 @@ function init() {
   const accessToken = userStore.user.access_token;
 
   mng.client.setConfig({
-    baseUrl: env.icebergCatalogUrl,
+    baseUrl: icebergCatalogUrl(),
   });
 
   mng.client.interceptors.request.use((request) => {
@@ -67,7 +67,7 @@ function init() {
   });
 
   ice.client.setConfig({
-    baseUrl: env.icebergCatalogUrlSuffixed,
+    baseUrl: icebergCatalogUrlSuffixed(),
   });
 
   ice.client.interceptors.request.use((request) => {
@@ -75,6 +75,20 @@ function init() {
     return request;
   });
 }
+
+const icebergCatalogUrl = (): string => {
+  let url = env.icebergCatalogUrl;
+
+  if (url === '' || url === 'VITE_APP_ICEBERG_CATALOG_URL_PLACEHOLDER' || url === undefined) {
+    url = `${location.protocol}//${location.hostname}${location.port ? `:${location.port}` : ''}`;
+  }
+
+  return url.substring(url.length - 1) === '/' ? url : `${url}/`;
+};
+
+const icebergCatalogUrlSuffixed = (): string => {
+  return icebergCatalogUrl() + 'catalog/';
+};
 
 function parseErrorText(errorText: string): { message: string; code: number } {
   const messageMatch = errorText.match(/: (.*) at/);
@@ -1725,6 +1739,8 @@ export function useFunctions() {
     whoAmI,
     getServerAssignments,
     updateServerAssignments,
+    icebergCatalogUrl,
+    icebergCatalogUrlSuffixed,
     getServerAccess,
     getNamespaceAssignmentsById,
     updateNamespaceAssignmentsById,


### PR DESCRIPTION
this will allow lakekeeper to be reachable under various urls, e.g. when running in docker and accessing from host