### PR TITLE
fix(console-rs): correct path to node build artifacts

### DIFF
--- a/console-rs/build.rs
+++ b/console-rs/build.rs
@@ -6,16 +6,17 @@ fn main() {
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let repo_dir = Path::new(&manifest_dir).parent().unwrap();
-    let node_dir = Path::new(&out_dir).join("node/dist");
+    let node_root = Path::new(&out_dir).join("node");
+    let asset_dir = node_root.join("dist");
 
-    println!("Node dir: {node_dir:?}");
-    println!("Repo dir: {repo_dir:?}");
+    println!("Node root: {node_root:?}");
+    println!("Asset dir (dist): {asset_dir:?}");
     // Copy everything from repo_dir to node_dir, we are not allowed to write anywhere else
-    fs::remove_dir_all(&node_dir).ok();
-    fs::create_dir_all(&node_dir).unwrap();
+    fs::remove_dir_all(&node_root).ok();
+    fs::create_dir_all(&asset_dir).unwrap();
     fs_extra::dir::copy(
         repo_dir,
-        &node_dir,
+        &node_root,
         &fs_extra::dir::CopyOptions::new().content_only(true),
     )
     .unwrap();
@@ -24,15 +25,15 @@ fn main() {
         .arg("-c")
         .arg(format!(
             "cd {} && HOME=\"{}\" npm ci",
-            node_dir.to_str().unwrap(),
-            node_dir.to_str().unwrap()
+            node_root.to_str().unwrap(),
+            node_root.to_str().unwrap()
         ))
-        .current_dir(node_dir.clone())
+        .current_dir(node_root.clone())
         .status()
         .expect("Failed to install Lakekeeper UI dependencies with npm");
     std::process::Command::new("npm")
         .args(["run", "build-placeholder"])
-        .current_dir(node_dir.clone())
+        .current_dir(node_root.clone())
         .status()
         .expect("Failed to build Lakekeeper UI with npm");
 }

--- a/console-rs/build.rs
+++ b/console-rs/build.rs
@@ -9,8 +9,11 @@ fn main() {
     let node_root = Path::new(&out_dir).join("node");
     let asset_dir = node_root.join("dist");
 
-    println!("Node root: {node_root:?}");
-    println!("Asset dir (dist): {asset_dir:?}");
+    println!("cargo:warning=Node root: {node_root:?}");
+    println!("cargo:warning=Asset dir (dist): {asset_dir:?}");
+    // limit rebuilds to UI changes
+    println!("cargo:rerun-if-changed={}", repo_dir.join("package.json").display());
+    println!("cargo:rerun-if-changed={}", repo_dir.join("package-lock.json").display());
     // Copy everything from repo_dir to node_dir, we are not allowed to write anywhere else
     fs::remove_dir_all(&node_root).ok();
     fs::create_dir_all(&asset_dir).unwrap();

--- a/console-rs/build.rs
+++ b/console-rs/build.rs
@@ -31,9 +31,21 @@ fn main() {
         .current_dir(node_root.clone())
         .status()
         .expect("Failed to install Lakekeeper UI dependencies with npm");
-    std::process::Command::new("npm")
+    let output = std::process::Command::new("npm")
         .args(["run", "build-placeholder"])
-        .current_dir(node_root.clone())
-        .status()
-        .expect("Failed to build Lakekeeper UI with npm");
+        .current_dir(&node_root)
+        .output()
+        .expect("Failed to spawn npm to build Lakekeeper UI");
+    if !output.status.success() {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    panic!(
+        "npm run build-placeholder failed with exit code: {:?}\n\
+         STDOUT:\n{stdout}\n\
+         STDERR:\n{stderr}\n\
+         Working directory: {}",
+        output.status.code(),
+        node_root.display()
+    );
+}
 }

--- a/console-rs/build.rs
+++ b/console-rs/build.rs
@@ -6,7 +6,7 @@ fn main() {
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let repo_dir = Path::new(&manifest_dir).parent().unwrap();
-    let node_dir = Path::new(&out_dir).join("node");
+    let node_dir = Path::new(&out_dir).join("node/dist");
 
     println!("Node dir: {node_dir:?}");
     println!("Repo dir: {repo_dir:?}");

--- a/console-rs/build.rs
+++ b/console-rs/build.rs
@@ -14,6 +14,9 @@ fn main() {
     // limit rebuilds to UI changes
     println!("cargo:rerun-if-changed={}", repo_dir.join("package.json").display());
     println!("cargo:rerun-if-changed={}", repo_dir.join("package-lock.json").display());
+    println!("cargo:rerun-if-changed={}", repo_dir.join("src").display());
+    println!("cargo:rerun-if-changed={}", repo_dir.join("public").display());
+    println!("cargo:rerun-if-changed={}", repo_dir.join("vite.config.js").display());
     // Copy everything from repo_dir to node_dir, we are not allowed to write anywhere else
     fs::remove_dir_all(&node_root).ok();
     fs::create_dir_all(&asset_dir).unwrap();


### PR DESCRIPTION
Follow-up on https://github.com/lakekeeper/console/pull/148
Closes https://github.com/lakekeeper/console/issues/147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clearer debug and trace messages indicating Node root and asset paths during build.
- Refactor
  - Standardized build structure by introducing a Node root and a dedicated assets directory for distribution.
  - Updated file operations and copy steps to align with the new directory layout.
- Chores
  - Adjusted npm commands and working directories to the new structure.
  - Maintained dependency installation and build steps while scoping them to the updated paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->