### PR TITLE
feat: filter warehouses

### DIFF
--- a/src/pages/warehouse/index.vue
+++ b/src/pages/warehouse/index.vue
@@ -176,15 +176,15 @@ const filteredWarehouses = computed(() => {
   const searchLower = searchWarehouse.value.toLowerCase();
 
   return whResponse.filter((warehouse) => {
-    // Only matches if 'name' ends with the search term
-    const nameEndsWith = warehouse.name
-      ? warehouse.name.toLowerCase().endsWith(searchLower)
-      : false;
+    // Matches if 'name' contains the search term
+    const nameMatches = warehouse.name ? warehouse.name.toLowerCase().includes(searchLower) : false;
 
-    // Only matches if 'id' ends with the search term
-    const idEndsWith = warehouse.id ? warehouse.id.toLowerCase().endsWith(searchLower) : false;
+    // Matches if 'id' contains the search term (only if search term has UUID semantic)
+    const hasUuidSemantic = /^[0-9a-f-]+$/.test(searchLower);
+    const idMatches =
+      warehouse.id && hasUuidSemantic ? warehouse.id.toLowerCase().includes(searchLower) : false;
 
-    return nameEndsWith || idEndsWith;
+    return nameMatches || idMatches;
   });
 });
 

--- a/src/pages/warehouse/index.vue
+++ b/src/pages/warehouse/index.vue
@@ -34,11 +34,31 @@
         </v-toolbar>
         <v-data-table
           v-if="myAccess.includes('list_warehouses')"
+          height="60vh"
+          :search="searchWarehouse"
           fixed-header
           :headers="headers"
           hover
+          items-per-page="50"
           :items="whResponse"
-          :sort-by="[{ key: 'name', order: 'asc' }]">
+          :sort-by="[{ key: 'name', order: 'asc' }]"
+          :items-per-page-options="[
+            { title: '50 items', value: 50 },
+            { title: '100 items', value: 100 },
+          ]"
+          @update:options="paginationCheckWarehouse($event)">
+          <template #top>
+            <v-toolbar color="transparent" density="compact" flat>
+              <v-spacer></v-spacer>
+              <v-text-field
+                v-model="searchWarehouse"
+                label="Filter results"
+                prepend-inner-icon="mdi-filter"
+                variant="underlined"
+                hide-details
+                clearable></v-text-field>
+            </v-toolbar>
+          </template>
           <template #item.name="{ item }">
             <td class="pointer-cursor" @click="navigateToWarehouse(item)">
               <span class="icon-text">
@@ -127,11 +147,12 @@ import { GetWarehouseResponse, ProjectAction } from '../../gen/management/types.
 import router from '../../router';
 import { useFunctions } from '../../plugins/functions';
 import { useVisualStore } from '../../stores/visual';
-import { Header } from '../../common/interfaces';
+import { Header, Options } from '../../common/interfaces';
 
 const functions = useFunctions();
 const missAccessPermission = ref(true);
 const loading = ref(true);
+const searchWarehouse = ref('');
 
 const headers: readonly Header[] = Object.freeze([
   { title: 'Name', key: 'name', align: 'start' },
@@ -164,6 +185,15 @@ onMounted(async () => {
     console.error('Failed to load data:', err);
   }
 });
+
+async function paginationCheckWarehouse(option: Options) {
+  // Note: Currently listWarehouses doesn't support pagination tokens
+  // This function is here for consistency and future pagination support
+  if (whResponse.length >= 10000) return;
+
+  // Pagination logic would go here when API supports it
+  // For now, all warehouses are loaded at once
+}
 
 async function listWarehouse() {
   try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a top toolbar with a search bar to filter warehouses by name or ID (case-insensitive).
  - Enabled dynamic, client-side filtering for the warehouse list.
  - Introduced an items-per-page selector with 50 (default) and 100 options to control list length.

- Style
  - Adjusted the warehouse list height to 60vh for improved on-screen visibility and browsing comfort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->