### PR TITLE
chore: silence baseUrl deprecation for TypeScript 6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ESNext",
     "jsx": "preserve",
     "lib": ["DOM", "ESNext"],
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "module": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- Add `"ignoreDeprecations": "6.0"` to `tsconfig.json`
- TypeScript 6 promotes `baseUrl` deprecation (TS5101) from warning to build error, which breaks the embedded frontend build in the Rust CI job
- Unblocks the Renovate TypeScript v6 upgrade PR (#234)
- `baseUrl` removal is tracked for the TypeScript 7 migration

BEGIN_COMMIT_OVERRIDE
chore(ui): silence baseUrl deprecation for TypeScript 6 compatibility
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)