### PR TITLE
chore: upgrade TypeScript to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "globals": "^16.5.0",
         "pinia": "^3.0.3",
         "prettier": "^3.6.2",
-        "typescript": "~5.9.3",
+        "typescript": "~6.0.3",
         "typescript-eslint": "^8.46.3",
         "unplugin-auto-import": "^21.0.0",
         "unplugin-fonts": "^1.1.1",
@@ -4812,9 +4812,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "globals": "^16.5.0",
     "pinia": "^3.0.3",
     "prettier": "^3.6.2",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.46.3",
     "unplugin-auto-import": "^21.0.0",
     "unplugin-fonts": "^1.1.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ESNext",
     "jsx": "preserve",
     "lib": ["DOM", "ESNext"],
+    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "module": "ESNext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
- Bump `typescript` from `~5.9.3` to `~6.0.3`
- Add `"ignoreDeprecations": "6.0"` to `tsconfig.json` — TypeScript 6 promotes the `baseUrl` deprecation (TS5101) from warning to error
- Supersedes Renovate PR #234

BEGIN_COMMIT_OVERRIDE
chore(ui): upgrade TypeScript to v6 and silence baseUrl deprecation
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)