### PR TITLE
chore: ignore major upgrades for typescript, vuetify, and eslint

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,11 @@
     {
       "matchUpdateTypes": ["patch"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["typescript", "vuetify", "/eslint/"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Ignore TypeScript, Vuetify, and ESLint **major** version bumps in `renovate.json`
- Deferring TypeScript 6/7, Vuetify 4, and ESLint major until explicitly planned as a coordinated upgrade
- Also closes Renovate PR #234 (TypeScript v6) which is now suppressed

BEGIN_COMMIT_OVERRIDE
chore(ui): ignore major upgrades for typescript, vuetify, and eslint
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)