### PR TITLE
chore: ignore @lakekeeper/console-components in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,11 @@
     {
       "matchUpdateTypes": ["patch"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["typescript", "vuetify", "/eslint/"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,10 @@
       "matchPackageNames": ["typescript", "vuetify", "/eslint/"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["@lakekeeper/console-components"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Ignore `@lakekeeper/console-components` in Renovate — it's installed from a GitHub URL, not the npm registry, so Renovate emits a lookup failure warning
- We bump this dependency manually when a new component version is released

BEGIN_COMMIT_OVERRIDE
chore(ui): ignore @lakekeeper/console-components in Renovate
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)