### PR TITLE
chore: configure Renovate datasource for @lakekeeper/* GitHub dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,11 @@
     {
       "matchUpdateTypes": ["patch"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["typescript", "vuetify", "/eslint/"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,11 @@
       "matchPackageNames": ["typescript", "vuetify", "/eslint/"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["@lakekeeper/console-components"],
+      "datasource": "github-releases",
+      "packageName": "lakekeeper/console-components"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Configure Renovate to use `github-releases` datasource for `@lakekeeper/console-components`
- Package is installed from a GitHub URL — Renovate was failing to look it up on npm and emitting a warning in the Dependency Dashboard
- With the correct datasource, Renovate will track new GitHub releases and propose version bumps properly

BEGIN_COMMIT_OVERRIDE
chore(ui): configure Renovate datasource for @lakekeeper/* GitHub dependencies
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)