### PR TITLE
chore: block all major dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,9 +24,13 @@
       "automerge": true
     },
     {
-      "matchPackageNames": ["typescript", "vuetify", "/eslint/"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["@lakekeeper/console-components"],
+      "datasource": "github-releases",
+      "packageName": "lakekeeper/console-components"
     }
   ]
 }


### PR DESCRIPTION
Block all major version bumps in Renovate (blanket rule), replacing the previous per-package ignore list. Majors are still visible in the Renovate Dependency Dashboard under "Ignored or Blocked" — no PRs are opened automatically.

Also fixes the Renovate lookup warning for `@lakekeeper/console-components` by adding `datasource: "github-releases"` so Renovate can properly track new releases.

BEGIN_COMMIT_OVERRIDE
chore(ui): block all major dependency updates in Renovate
END_COMMIT_OVERRIDE