### PR TITLE
fix: fix Renovate config error

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -26,11 +26,6 @@
     {
       "matchUpdateTypes": ["major"],
       "enabled": false
-    },
-    {
-      "matchPackageNames": ["@lakekeeper/console-components"],
-      "datasource": "github-releases",
-      "packageName": "lakekeeper/console-components"
     }
   ]
 }


### PR DESCRIPTION
Fixes #254 — `datasource` and `packageName` are not valid fields inside `packageRules` (schema validation error, Renovate stops creating PRs).

`@lakekeeper/console-components` is installed as `github:lakekeeper/console-components#vX.Y.Z` — Renovate's npm manager auto-detects the `github:` prefix and uses `github-releases` datasource natively. The override was never needed and caused the schema error.

BEGIN_COMMIT_OVERRIDE
chore(ui): fix Renovate config error caused by invalid packageRules fields
END_COMMIT_OVERRIDE