### PR TITLE
chore: require dashboard approval for major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
     },
     {
       "matchUpdateTypes": ["major"],
-      "enabled": false
+      "dependencyDashboardApproval": true
     }
   ]
 }


### PR DESCRIPTION
Replaces `enabled: false` with `dependencyDashboardApproval: true` for major updates.

- Patch → automerge
- Minor → automatic PR
- Major → checkbox in Dependency Dashboard; PR only opens when you click it

BEGIN_COMMIT_OVERRIDE
chore(ui): require dashboard approval for major dependency updates
END_COMMIT_OVERRIDE