### PR TITLE
ci: skip release-please for Dependabot PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ vars.RUNS_ON__AMD_XS || 'ubuntu-24.04' }}
     container:
       image: quay.io/vakamo/build-base:ubuntu-24-04
-    if: ${{ vars.RELEASE_PLEASE_ACTIVATED != '' }}
+    if: ${{ vars.RELEASE_PLEASE_ACTIVATED != '' && github.actor != 'dependabot[bot]' }}
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs['tag_name'] }}


### PR DESCRIPTION
## Summary
Dependabot PRs cannot access repository secrets (`RELEASE_PLEASE_TOKEN`), causing the release-please job to fail with "Input required and not supplied: token".

Skip the job when the actor is `dependabot[bot]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)