### PR TITLE
ci: add Dependabot config with lakekeeper dep ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    ignore:
+      - dependency-name: "@lakekeeper/console-components"
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vuetify"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "*eslint*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+    groups:
+      eslint:
+        patterns:
+          - "*eslint*"
+          - "globals"
+      vue-ecosystem:
+        patterns:
+          - "vue"
+          - "vue-*"
+          - "@vue/*"
+          - "vuetify"
+          - "pinia"
+          - "vue-tsc"
+      vite:
+        patterns:
+          - "vite"
+          - "vite-*"
+          - "@vitejs/*"
+      playwright:
+        patterns:
+          - "@playwright/*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` (was missing)
- Ignore `@lakekeeper/console-components` — managed manually via tagged releases, Dependabot would otherwise bump to unreleased commit SHAs
- Ignore major bumps for typescript, vuetify, eslint, @types/node
- Add grouping rules (eslint, vue-ecosystem, vite, playwright) matching console-plus

🤖 Generated with [Claude Code](https://claude.com/claude-code)