### PR TITLE
fix: bump console-components to v0.5.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "catalog",
       "version": "0.10.3",
       "dependencies": {
-        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.5.4",
+        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.5.5",
         "@mdi/font": "7.4.47",
         "json-bigint": "^1.0.0",
         "oidc-client-ts": "^3.3.0",
@@ -188,9 +188,9 @@
       }
     },
     "node_modules/@codemirror/search": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
-      "integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
+      "integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.0.0",
@@ -673,8 +673,8 @@
       "license": "MIT"
     },
     "node_modules/@lakekeeper/console-components": {
-      "version": "0.5.4",
-      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#a60096ad5bb42c18ad58c70f8accc04c3da0ea61",
+      "version": "0.5.5",
+      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#67dcf154a5bb9188a1a25d064c9506f42a05b060",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "node": ">=24"
   },
   "dependencies": {
-    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.5.4",
+    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.5.5",
     "@mdi/font": "7.4.47",
     "json-bigint": "^1.0.0",
     "oidc-client-ts": "^3.3.0",

--- a/src/pages/warehouse/[id].namespace.[nsid].table.[tid].vue
+++ b/src/pages/warehouse/[id].namespace.[nsid].table.[tid].vue
@@ -99,6 +99,7 @@
                 <TablePreview
                   v-if="tab === 'preview'"
                   :warehouse-id="params.id"
+                  :warehouse-name="warehouse?.name"
                   :namespace-id="namespacePath"
                   :table-name="params.tid"
                   :catalog-url="catalogUrl"


### PR DESCRIPTION
## Summary
- Bumps `@lakekeeper/console-components` to v0.5.5
- Passes `warehouse-name` prop to `TablePreview` so it stays current after a rename

BEGIN_COMMIT_OVERRIDE
fix(ui): bump console-components to v0.5.5
fix(ui): pass warehouse-name to TablePreview to fix stale name after rename
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)