### PR TITLE
fix: bump console-components to v0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.3",
       "dependencies": {
         "@formbricks/js": "^4.4.0",
-        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.6.0",
+        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.6.1",
         "@mdi/font": "7.4.47",
         "json-bigint": "^1.0.0",
         "oidc-client-ts": "^3.3.0",
@@ -731,8 +731,8 @@
       "license": "MIT"
     },
     "node_modules/@lakekeeper/console-components": {
-      "version": "0.6.0",
-      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#3f86311bbf96e201b9a1929207ab5424e595c257",
+      "version": "0.6.1",
+      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#302f3e01b83906f8777441c73c1d7097ce33fd9c",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
@@ -2604,9 +2604,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.2.1.tgz",
-      "integrity": "sha512-37RhSdxaG1suen6VDCza6rNrQfooyQh57HFVPwQGEq2QWliVLzPQZ8Oa017weOu+HZCnzI7N3Pf/wyoBKfEqrA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.3.0.tgz",
+      "integrity": "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@formbricks/js": "^4.4.0",
-    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.6.0",
+    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.6.1",
     "@mdi/font": "7.4.47",
     "json-bigint": "^1.0.0",
     "oidc-client-ts": "^3.3.0",

--- a/src/assets/dependencies.json
+++ b/src/assets/dependencies.json
@@ -8,7 +8,7 @@
       },
       {
         "name": "@lakekeeper/console-components",
-        "version": "github:lakekeeper/console-components#v0.6.0"
+        "version": "github:lakekeeper/console-components#v0.6.1"
       },
       {
         "name": "@mdi/font",
@@ -143,7 +143,7 @@
     ]
   },
   "components": {
-    "version": "0.6.0",
+    "version": "0.6.1",
     "dependencies": [
       {
         "name": "@codemirror/commands",
@@ -317,7 +317,7 @@
   },
   "rust": {
     "version": "0.12.2",
-    "rustVersion": "1.92",
+    "rustVersion": "1.94",
     "dependencies": [
       {
         "name": "anyhow",
@@ -681,7 +681,7 @@
       },
       {
         "name": "sqlx",
-        "version": "0.8.6",
+        "version": "0.9.0",
         "features": ""
       },
       {


### PR DESCRIPTION
## Summary

Bumps `@lakekeeper/console-components` from v0.6.0 to v0.6.1. This brings in the merged Renovate dep updates (typescript-eslint, eslint-plugin-vue, vue-router, vue-tsc, sql-formatter, @codemirror/view) plus the README typo fix.

## Test plan

- [ ] `just reviewable` passes
- [ ] Dependencies page reflects v0.6.1 versions
- [ ] All previously-tested flows still work (SQL editor, routing, dialogs, AppBar feedback/export buttons)

BEGIN_COMMIT_OVERRIDE
fix(deps): bump @lakekeeper/console-components to v0.6.1
chore(ui): regenerate dependencies.json
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)