### PR TITLE
fix: bump console-components to v0.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.3",
       "dependencies": {
         "@formbricks/js": "^4.4.0",
-        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.6.1",
+        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.6.2",
         "@mdi/font": "7.4.47",
         "json-bigint": "^1.0.0",
         "oidc-client-ts": "^3.3.0",
@@ -731,8 +731,8 @@
       "license": "MIT"
     },
     "node_modules/@lakekeeper/console-components": {
-      "version": "0.6.1",
-      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#302f3e01b83906f8777441c73c1d7097ce33fd9c",
+      "version": "0.6.2",
+      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#5f5186b084ad103642cfc697bf86e25d3237fdfd",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@formbricks/js": "^4.4.0",
-    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.6.1",
+    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.6.2",
     "@mdi/font": "7.4.47",
     "json-bigint": "^1.0.0",
     "oidc-client-ts": "^3.3.0",

--- a/src/assets/dependencies.json
+++ b/src/assets/dependencies.json
@@ -8,7 +8,7 @@
       },
       {
         "name": "@lakekeeper/console-components",
-        "version": "github:lakekeeper/console-components#v0.6.1"
+        "version": "github:lakekeeper/console-components#v0.6.2"
       },
       {
         "name": "@mdi/font",
@@ -143,7 +143,7 @@
     ]
   },
   "components": {
-    "version": "0.6.1",
+    "version": "0.6.2",
     "dependencies": [
       {
         "name": "@codemirror/commands",
@@ -209,7 +209,7 @@
       },
       {
         "name": "@hey-api/openapi-ts",
-        "version": "^0.87.0"
+        "version": "^0.97.0"
       },
       {
         "name": "@types/d3",


### PR DESCRIPTION
## Summary

Bumps `@lakekeeper/console-components` from v0.6.1 to v0.6.2 — brings in the `@hey-api/openapi-ts 0.97` SDK regen (leaner generated code, same public API).

## Test plan

- [ ] `just reviewable` passes
- [ ] Server overview, warehouses, namespaces, tables, permissions load normally

BEGIN_COMMIT_OVERRIDE
fix(deps): bump @lakekeeper/console-components to v0.6.2
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)