### PR TITLE
fix: bump console-components to v0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.3",
       "dependencies": {
         "@formbricks/js": "^4.4.0",
-        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.6.2",
+        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.7.0",
         "@mdi/font": "7.4.47",
         "json-bigint": "^1.0.0",
         "oidc-client-ts": "^3.3.0",
@@ -50,14 +50,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "8.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.5.tgz",
-      "integrity": "sha512-nFZPWz3FHIS7y6rMIVoa/WBwjdutfIaRJIBQjzn+t3RnecZoRNlGmGcyR2wb0T/IgSd50Kz/6dG8/LvMCRunjg==",
+      "version": "8.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.6.tgz",
+      "integrity": "sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^8.0.0-rc.5",
-        "@babel/types": "^8.0.0-rc.5",
+        "@babel/parser": "^8.0.0-rc.6",
+        "@babel/types": "^8.0.0-rc.6",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "@types/jsesc": "^2.5.0",
@@ -68,9 +68,9 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.5.tgz",
-      "integrity": "sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==",
+      "version": "8.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.6.tgz",
+      "integrity": "sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.5.tgz",
-      "integrity": "sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==",
+      "version": "8.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.6.tgz",
+      "integrity": "sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -88,13 +88,13 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/parser": {
-      "version": "8.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.5.tgz",
-      "integrity": "sha512-/Mfg83rK3+jsRbl4Vbd0jqxc6M1A1/WNFtgrowRM1unEsD3XcNnrBdMM0JWakd0/RN9lseQKwPduW1TiEwKOlQ==",
+      "version": "8.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.6.tgz",
+      "integrity": "sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^8.0.0-rc.5"
+        "@babel/types": "^8.0.0-rc.6"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -104,14 +104,14 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/types": {
-      "version": "8.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.5.tgz",
-      "integrity": "sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==",
+      "version": "8.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.6.tgz",
+      "integrity": "sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0-rc.5",
-        "@babel/helper-validator-identifier": "^8.0.0-rc.5"
+        "@babel/helper-string-parser": "^8.0.0-rc.6",
+        "@babel/helper-validator-identifier": "^8.0.0-rc.6"
       },
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
@@ -731,8 +731,8 @@
       "license": "MIT"
     },
     "node_modules/@lakekeeper/console-components": {
-      "version": "0.6.2",
-      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#5f5186b084ad103642cfc697bf86e25d3237fdfd",
+      "version": "0.7.0",
+      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#77ceb0eadce7c9d2a11462b3328ba6eedbd477db",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@formbricks/js": "^4.4.0",
-    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.6.2",
+    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.7.0",
     "@mdi/font": "7.4.47",
     "json-bigint": "^1.0.0",
     "oidc-client-ts": "^3.3.0",

--- a/src/assets/dependencies.json
+++ b/src/assets/dependencies.json
@@ -8,7 +8,7 @@
       },
       {
         "name": "@lakekeeper/console-components",
-        "version": "github:lakekeeper/console-components#v0.6.2"
+        "version": "github:lakekeeper/console-components#v0.7.0"
       },
       {
         "name": "@mdi/font",
@@ -143,7 +143,7 @@
     ]
   },
   "components": {
-    "version": "0.6.2",
+    "version": "0.7.0",
     "dependencies": [
       {
         "name": "@codemirror/commands",


### PR DESCRIPTION
## Summary

- Bumps `@lakekeeper/console-components` v0.6.2 → v0.7.0

Brings in role-management improvements + listRoles array query fix:
- Provider column and multi-select provider filter on the role list, description column truncated with hover tooltip
- Redesigned role detail card (avatar, chips, two-column metadata grid, scrollable description, in-card Back/Edit)
- `listRoles` arrays encoded as `key[]=value` so the serde_qs backend accepts provider/source filters
- Dropped frontend-only role name min length and description max length
- Review fixes: whitespace-name rejection, debounced-search cancel on filter change, aria-labels on copy buttons, typed `Role` state

## Test plan

- [ ] `just reviewable` passes (already green locally)
- [ ] Role list shows new Provider column + filter; truncated description tooltip works
- [ ] Role detail card renders with new layout; copy buttons + description scroll work
- [ ] Creating a role with a long description (>500 chars) succeeds; whitespace-only name is rejected
- [ ] Dependencies page reflects v0.7.0

BEGIN_COMMIT_OVERRIDE
fix(ui): bump @lakekeeper/console-components to v0.7.0
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)