### PR TITLE
feat: default Identities to Users tab, fix home logo, bump components to v0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.10.3",
       "dependencies": {
         "@formbricks/js": "^4.4.0",
-        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.11.0",
+        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.12.0",
         "@mdi/font": "7.4.47",
         "json-bigint": "^1.0.0",
         "oidc-client-ts": "^3.3.0",
@@ -732,8 +732,8 @@
       "license": "MIT"
     },
     "node_modules/@lakekeeper/console-components": {
-      "version": "0.11.0",
-      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#bf1a482a506db5ea482f0be98789c3effdc7d9ea",
+      "version": "0.12.0",
+      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#af24b12ee8e43ac4d6c6aa542db3aa7c43e5630e",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
@@ -4113,9 +4113,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@formbricks/js": "^4.4.0",
-    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.11.0",
+    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.12.0",
     "@mdi/font": "7.4.47",
     "json-bigint": "^1.0.0",
     "oidc-client-ts": "^3.3.0",

--- a/src/assets/dependencies.json
+++ b/src/assets/dependencies.json
@@ -8,7 +8,7 @@
       },
       {
         "name": "@lakekeeper/console-components",
-        "version": "github:lakekeeper/console-components#v0.11.0"
+        "version": "github:lakekeeper/console-components#v0.12.0"
       },
       {
         "name": "@mdi/font",
@@ -143,7 +143,7 @@
     ]
   },
   "components": {
-    "version": "0.11.0",
+    "version": "0.12.0",
     "dependencies": [
       {
         "name": "@codemirror/commands",

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -19,12 +19,14 @@
             v-if="visual.themeLight"
             class="mx-auto"
             max-width="280"
+            :aspect-ratio="1"
             lazy-src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='280' height='80'%3E%3Crect fill='%23f5f5f5' width='280' height='80' rx='8'/%3E%3C/svg%3E"
             src="@/assets/LAKEKEEPER_IMAGE_TEXT.svg" />
           <v-img
             v-else
             class="mx-auto"
             max-width="280"
+            :aspect-ratio="1"
             lazy-src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='280' height='80'%3E%3Crect fill='%23333' width='280' height='80' rx='8'/%3E%3C/svg%3E"
             src="@/assets/LAKEKEEPER_IMAGE_TEXT_WHITE.svg" />
         </v-col>

--- a/src/pages/identities.vue
+++ b/src/pages/identities.vue
@@ -1,18 +1,23 @@
 <template>
   <div class="ma-2">
-    <v-tabs v-model="tab">
-      <v-tab v-if="showUsersTab" value="users">Users</v-tab>
-      <v-tab value="roles">Roles</v-tab>
-    </v-tabs>
-    <v-tabs-window v-model="tab" style="max-height: calc(100vh - 140px); overflow-y: auto">
-      <v-tabs-window-item value="roles">
-        <RoleDetail v-if="selectedRoleId" :role-id="selectedRoleId" :can-edit="canManageGrants" />
-        <RoleManager v-else inline @select="selectRole" />
-      </v-tabs-window-item>
-      <v-tabs-window-item v-if="showUsersTab" value="users">
-        <UserManager v-if="tab === 'users'" />
-      </v-tabs-window-item>
-    </v-tabs-window>
+    <div v-if="permsLoading" class="d-flex justify-center pa-8">
+      <v-progress-circular color="primary" indeterminate></v-progress-circular>
+    </div>
+    <template v-else>
+      <v-tabs v-model="tab">
+        <v-tab v-if="showUsersTab" value="users">Users</v-tab>
+        <v-tab value="roles">Roles</v-tab>
+      </v-tabs>
+      <v-tabs-window v-model="tab" style="max-height: calc(100vh - 140px); overflow-y: auto">
+        <v-tabs-window-item value="roles">
+          <RoleDetail v-if="selectedRoleId" :role-id="selectedRoleId" :can-edit="canManageGrants" />
+          <RoleManager v-else inline @select="selectRole" />
+        </v-tabs-window-item>
+        <v-tabs-window-item v-if="showUsersTab" value="users">
+          <UserManager v-if="tab === 'users'" />
+        </v-tabs-window-item>
+      </v-tabs-window>
+    </template>
   </div>
 </template>
 
@@ -29,9 +34,9 @@ const route = useRoute();
 const router = useRouter();
 const visual = useVisualStore();
 
-const serverId = ref('');
-const { showUsersTab } = useServerPermissions(serverId);
-const tab = ref('roles');
+const serverId = ref(visual.getServerInfo()['server-id'] || '');
+const { showUsersTab, loading: permsLoading } = useServerPermissions(serverId);
+const tab = ref((route.query.tab as string) || 'users');
 
 // Role detail renders in-place (stay on the Roles tab) via a ?role query param.
 const selectedRoleId = computed(() => (route.query.role as string) || '');
@@ -42,8 +47,14 @@ function selectRole(id: string) {
 }
 
 onMounted(() => {
-  serverId.value = visual.getServerInfo()['server-id'] || '';
-  if (route.query.tab) tab.value = route.query.tab as string;
+  if (!serverId.value) serverId.value = visual.getServerInfo()['server-id'] || '';
+});
+// Default to the Users tab; fall back to Roles only if the user lacks Users access.
+// Guarded against the empty-serverId window so it never flips to Roles and back.
+watch([permsLoading, showUsersTab], () => {
+  if (route.query.tab) return;
+  if (permsLoading.value || !serverId.value) return;
+  tab.value = showUsersTab.value ? 'users' : 'roles';
 });
 // Switching tab clears any selected role.
 watch(tab, (t) => {


### PR DESCRIPTION
## Summary
- **Identities** now defaults to the **Users** tab (falls back to Roles only when the user lacks Users access). Tabs render only after permissions resolve, eliminating the brief Roles→Users slide on load.
- **Home logo** fixed: the SVGs use a square `viewBox`, which made `v-img` pick the wrong ratio and collapse the logo; added `:aspect-ratio="1"` so it renders again.
- **Bump** `@lakekeeper/console-components` → `v0.12.0` (role owners above members + multi-select bulk remove).

## Test plan
- Open `/identities` → lands on Users with no flash.
- Home page shows the Lakekeeper logo (light + dark theme).
- Role detail: Owners above Members; multi-select + Remove (N) works.

BEGIN_COMMIT_OVERRIDE
fix(ui): bump console-components to v0.12.0
feat(ui): default Identities to the Users tab
fix(ui): render Identities tabs after permissions load to avoid Roles flash
fix(ui): render home logo by giving the v-img an explicit aspect ratio
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)