### PR TITLE
fix: drop leading slash from default UI client_id (default is "lakekeeper" now)

### DIFF
--- a/console-rs/src/lib.rs
+++ b/console-rs/src/lib.rs
@@ -47,7 +47,7 @@ impl Default for LakekeeperConsoleConfig {
     fn default() -> Self {
         Self {
             idp_authority: String::new(),
-            idp_client_id: "/lakekeeper".to_string(),
+            idp_client_id: "lakekeeper".to_string(),
             idp_redirect_path: "/callback".to_string(),
             idp_scope: "openid profile email".to_string(),
             idp_resource: String::new(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default console authentication client ID to use `lakekeeper` instead of `/lakekeeper`, improving out-of-the-box configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->