### PR TITLE
fix: bump console-components to v0.15.2 (working airgapped LoQE)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@fontsource/roboto": "^5.2.10",
         "@formbricks/js": "^4.4.0",
-        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.15.1",
+        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.15.2",
         "@mdi/font": "7.4.47",
         "json-bigint": "^1.0.0",
         "oidc-client-ts": "^3.3.0",
@@ -741,8 +741,8 @@
       "license": "MIT"
     },
     "node_modules/@lakekeeper/console-components": {
-      "version": "0.15.1",
-      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#f4b5fe273e1cbc76f1a52a00936f9bd90eeed69f",
+      "version": "0.15.2",
+      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#c0e23e639760da9de66ae26f2cb693e47f8ed024",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@fontsource/roboto": "^5.2.10",
     "@formbricks/js": "^4.4.0",
-    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.15.1",
+    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.15.2",
     "@mdi/font": "7.4.47",
     "json-bigint": "^1.0.0",
     "oidc-client-ts": "^3.3.0",

--- a/src/assets/dependencies.json
+++ b/src/assets/dependencies.json
@@ -12,7 +12,7 @@
       },
       {
         "name": "@lakekeeper/console-components",
-        "version": "github:lakekeeper/console-components#v0.15.1"
+        "version": "github:lakekeeper/console-components#v0.15.2"
       },
       {
         "name": "@mdi/font",
@@ -147,7 +147,7 @@
     ]
   },
   "components": {
-    "version": "0.15.1",
+    "version": "0.15.2",
     "dependencies": [
       {
         "name": "@codemirror/commands",


### PR DESCRIPTION
## What

Bump `@lakekeeper/console-components` → **v0.15.2**.

The prior bump (#343) landed at v0.15.1, which pinned LoQE's DuckDB extension repo to our own origin but shipped **no** extension binaries — so table create/preview failed with `IO Error: Unknown ABI type` (the app served `index.html` for the missing `/duckdb/extensions/*.wasm`). v0.15.2 vendors the extensions at build time, so the copy plugin serves valid binaries.

## Verified

- Fresh install of v0.15.2 ships `dist/duckdb/extensions/v1.4.3/{wasm_eh,wasm_mvp}/*` (10 files).
- `vue-tsc --noEmit` passes.

BEGIN_COMMIT_OVERRIDE
fix(ui): bump console-components to 0.15.2 for working airgapped LoQE extensions
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)