### PR TITLE
fix: reliably serve DuckDB extensions in dev (airgapped LoQE)

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -5,7 +5,7 @@ import Vue from '@vitejs/plugin-vue';
 import VueRouter from 'vue-router/vite';
 import Vuetify, { transformAssetUrls } from 'vite-plugin-vuetify';
 import { loadEnv, defineConfig } from 'vite';
-import { resolve } from 'path';
+import { resolve, relative, isAbsolute } from 'path';
 import { copyFileSync, mkdirSync, existsSync, rmSync, cpSync, createReadStream } from 'fs';
 // Utilities
 import { fileURLToPath, URL } from 'node:url';
@@ -32,10 +32,20 @@ function serveDuckDBExtensionsDev() {
         const idx = url.indexOf(marker);
         if (idx === -1 || !url.endsWith('.wasm')) return next();
         const filePath = resolve(extRoot, url.slice(idx + marker.length));
-        if (!filePath.startsWith(extRoot) || !existsSync(filePath)) return next();
+        // Boundary-aware containment: reject anything outside extRoot (prevents
+        // sibling-path bypass like `<extRoot>-evil/…` that a prefix check misses).
+        const rel = relative(extRoot, filePath);
+        if (rel.startsWith('..') || isAbsolute(rel) || !existsSync(filePath)) return next();
         res.setHeader('Content-Type', 'application/wasm');
         res.setHeader('Cache-Control', 'no-cache');
-        createReadStream(filePath).pipe(res);
+        const stream = createReadStream(filePath);
+        // Handle read errors (e.g. TOCTOU / unreadable file) so they don't crash
+        // the dev server with an unhandled stream exception.
+        stream.on('error', () => {
+          if (!res.headersSent) res.statusCode = 500;
+          res.end();
+        });
+        stream.pipe(res);
       });
     },
   };

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -6,9 +6,39 @@ import VueRouter from 'vue-router/vite';
 import Vuetify, { transformAssetUrls } from 'vite-plugin-vuetify';
 import { loadEnv, defineConfig } from 'vite';
 import { resolve } from 'path';
-import { copyFileSync, mkdirSync, existsSync, rmSync, cpSync } from 'fs';
+import { copyFileSync, mkdirSync, existsSync, rmSync, cpSync, createReadStream } from 'fs';
 // Utilities
 import { fileURLToPath, URL } from 'node:url';
+
+// Dev-only: serve DuckDB extension binaries directly from console-components' dist,
+// ahead of Vite's SPA history fallback. Copying them into publicDir is unreliable
+// in `vite dev` — the SPA fallback intermittently returns index.html for
+// /duckdb/extensions/*.wasm, which DuckDB then parses as a binary ("Unknown ABI
+// type" / "need to see wasm magic number"). This middleware makes it deterministic.
+// Production build still serves them from dist via copyDuckDBFiles → publicDir.
+function serveDuckDBExtensionsDev() {
+  const extRoot = resolve(
+    __dirname,
+    'node_modules/@lakekeeper/console-components/dist/duckdb/extensions',
+  );
+  const marker = '/duckdb/extensions/';
+  return {
+    name: 'serve-duckdb-extensions-dev',
+    apply: 'serve' as const,
+    configureServer(server: { middlewares: { use: (fn: unknown) => void } }) {
+      server.middlewares.use((req: any, res: any, next: () => void) => {
+        const url = (req.url || '').split('?')[0];
+        const idx = url.indexOf(marker);
+        if (idx === -1 || !url.endsWith('.wasm')) return next();
+        const filePath = resolve(extRoot, url.slice(idx + marker.length));
+        if (!filePath.startsWith(extRoot) || !existsSync(filePath)) return next();
+        res.setHeader('Content-Type', 'application/wasm');
+        res.setHeader('Cache-Control', 'no-cache');
+        createReadStream(filePath).pipe(res);
+      });
+    },
+  };
+}
 
 // Plugin to copy DuckDB files from console-components.
 // COI (cross-origin isolated) bundle is intentionally omitted — LoQEEngine
@@ -72,6 +102,7 @@ export default defineConfig(({ mode }) => {
     base: `${env.VITE_BASE_URL_PREFIX || ''}/ui/`,
     plugins: [
       copyDuckDBFiles(), // Copy DuckDB files from console-components
+      serveDuckDBExtensionsDev(), // Dev: serve extension .wasm ahead of SPA fallback
       VueRouter({
         dts: 'src/typed-router.d.ts',
       }),

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -9,6 +9,7 @@ import { resolve } from 'path';
 import { copyFileSync, mkdirSync, existsSync, rmSync, cpSync, createReadStream } from 'fs';
 // Utilities
 import { fileURLToPath, URL } from 'node:url';
+import type { IncomingMessage, ServerResponse } from 'node:http';
 
 // Dev-only: serve DuckDB extension binaries directly from console-components' dist,
 // ahead of Vite's SPA history fallback. Copying them into publicDir is unreliable
@@ -26,7 +27,7 @@ function serveDuckDBExtensionsDev() {
     name: 'serve-duckdb-extensions-dev',
     apply: 'serve' as const,
     configureServer(server: { middlewares: { use: (fn: unknown) => void } }) {
-      server.middlewares.use((req: any, res: any, next: () => void) => {
+      server.middlewares.use((req: IncomingMessage, res: ServerResponse, next: () => void) => {
         const url = (req.url || '').split('?')[0];
         const idx = url.indexOf(marker);
         if (idx === -1 || !url.endsWith('.wasm')) return next();


### PR DESCRIPTION
## Problem

In `vite dev`, LoQE intermittently failed to load `httpfs`/`iceberg` with `IO Error: Unknown ABI type of value 'N'` (N varies) / `need to see wasm magic number`. Cause: Vite's SPA history fallback returns `index.html` for `public/duckdb/extensions/*.wasm` even when the files exist, so DuckDB parses HTML as a binary. Copying the extensions into `publicDir` is not reliable in dev.

## Fix

Add a **dev-only** (`apply: 'serve'`) Vite middleware that serves `/duckdb/extensions/*.wasm` directly from `node_modules/@lakekeeper/console-components/dist/duckdb/extensions`, registered ahead of the SPA fallback. Deterministic; reads from disk per request. Includes a path-traversal guard and `application/wasm` content-type.

Production is unaffected — the middleware only runs in `serve` mode; the built `dist/duckdb/extensions` is served by a normal static server (via `copyDuckDBFiles`), which never had the SPA-fallback quirk.

BEGIN_COMMIT_OVERRIDE
fix(ui): serve DuckDB extensions via dev middleware so airgapped LoQE loads reliably
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed development-time loading of DuckDB WebAssembly extensions so `.wasm` files are served correctly instead of falling back to the app page.
  * Improved handling of extension requests to ensure the correct file is returned with the proper WebAssembly content type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->