### PR TITLE
chore: redesign dependencies page as filterable virtualized table

### DIFF
--- a/src/pages/dependencies.vue
+++ b/src/pages/dependencies.vue
@@ -1,273 +1,355 @@
 <template>
-  <v-container fluid>
-    <v-row>
-      <v-col>
-        <h1 class="text-h4 mb-4">Project Dependencies</h1>
+  <div class="deps-page">
+    <div class="deps-inner">
+      <!-- Hero -->
+      <header class="deps-hero">
+        <p class="deps-eyebrow">Transparency</p>
+        <h1 class="deps-title">Dependencies</h1>
+      </header>
 
-        <v-tabs v-model="tab" color="primary">
-          <v-tab value="console">Console (Frontend)</v-tab>
-          <v-tab value="components">Console Components (Library)</v-tab>
-          <v-tab value="backend">Lakekeeper (Backend - Rust)</v-tab>
-        </v-tabs>
+      <!-- Controls -->
+      <div class="deps-controls">
+        <v-select
+          v-model="selectedSource"
+          :items="selectItems"
+          label="Package"
+          density="comfortable"
+          hide-details
+          class="deps-select"></v-select>
 
-        <v-card class="mt-4">
-          <v-tabs-window v-model="tab">
-            <!-- Console Dependencies -->
-            <v-tabs-window-item value="console">
-              <v-card-text>
-                <h2 class="text-h5 mb-4">Console Application</h2>
+        <v-text-field
+          v-model="search"
+          label="Search"
+          prepend-inner-icon="mdi-magnify"
+          density="comfortable"
+          clearable
+          hide-details
+          class="deps-search"></v-text-field>
 
-                <v-expansion-panels class="mb-4">
-                  <v-expansion-panel>
-                    <v-expansion-panel-title>
-                      <div class="d-flex align-center">
-                        <v-icon class="mr-2" color="success">mdi-package-variant</v-icon>
-                        <strong>Runtime Dependencies ({{ consoleDeps.length }})</strong>
-                      </div>
-                    </v-expansion-panel-title>
-                    <v-expansion-panel-text>
-                      <div style="max-height: 60vh; overflow-y: auto">
-                        <v-list density="compact">
-                          <v-list-item
-                            v-for="dep in consoleDeps"
-                            :key="dep.name"
-                            class="dependency-item">
-                            <template v-slot:prepend>
-                              <v-icon size="small">mdi-circle-small</v-icon>
-                            </template>
-                            <v-list-item-title>
-                              <code>{{ dep.name }}</code>
-                            </v-list-item-title>
-                            <v-list-item-subtitle>{{ dep.version }}</v-list-item-subtitle>
-                          </v-list-item>
-                        </v-list>
-                      </div>
-                    </v-expansion-panel-text>
-                  </v-expansion-panel>
+        <p class="deps-count">{{ visibleCount }} of {{ filteredItems.length }}</p>
+      </div>
 
-                  <v-expansion-panel>
-                    <v-expansion-panel-title>
-                      <div class="d-flex align-center">
-                        <v-icon class="mr-2" color="info">mdi-tools</v-icon>
-                        <strong>Dev Dependencies ({{ consoleDevDeps.length }})</strong>
-                      </div>
-                    </v-expansion-panel-title>
-                    <v-expansion-panel-text>
-                      <div style="max-height: 60vh; overflow-y: auto">
-                        <v-list density="compact">
-                          <v-list-item
-                            v-for="dep in consoleDevDeps"
-                            :key="dep.name"
-                            class="dependency-item">
-                            <template v-slot:prepend>
-                              <v-icon size="small">mdi-circle-small</v-icon>
-                            </template>
-                            <v-list-item-title>
-                              <code>{{ dep.name }}</code>
-                            </v-list-item-title>
-                            <v-list-item-subtitle>{{ dep.version }}</v-list-item-subtitle>
-                          </v-list-item>
-                        </v-list>
-                      </div>
-                    </v-expansion-panel-text>
-                  </v-expansion-panel>
-                </v-expansion-panels>
-              </v-card-text>
-            </v-tabs-window-item>
+      <!-- Table -->
+      <div class="deps-table-wrap">
+        <v-data-table-virtual
+          :headers="headers"
+          :items="filteredItems"
+          :search="search"
+          height="640"
+          fixed-header
+          density="comfortable"
+          hover
+          item-value="rowKey"
+          class="deps-table">
+          <template #item.name="{ item }">
+            <code class="dep-mono dep-name">{{ item.name }}</code>
+          </template>
 
-            <!-- Console Components Dependencies -->
-            <v-tabs-window-item value="components">
-              <v-card-text>
-                <h2 class="text-h5 mb-4">Console Components Library</h2>
+          <template #item.version="{ item }">
+            <div class="dep-version">
+              <span class="dep-mono dep-version-text" :title="item.fullVersion">
+                {{ shortVersion(item.version) }}
+              </span>
+              <span v-if="item.features" class="dep-mono dep-features">{{ item.features }}</span>
+            </div>
+          </template>
 
-                <v-expansion-panels class="mb-4">
-                  <v-expansion-panel>
-                    <v-expansion-panel-title>
-                      <div class="d-flex align-center">
-                        <v-icon class="mr-2" color="success">mdi-package-variant</v-icon>
-                        <strong>Runtime Dependencies ({{ componentsDeps.length }})</strong>
-                      </div>
-                    </v-expansion-panel-title>
-                    <v-expansion-panel-text>
-                      <v-list density="compact">
-                        <div style="max-height: 60vh; overflow-y: auto">
-                          <v-list-item
-                            v-for="dep in componentsDeps"
-                            :key="dep.name"
-                            class="dependency-item">
-                            <template v-slot:prepend>
-                              <v-icon size="small">mdi-circle-small</v-icon>
-                            </template>
-                            <v-list-item-title>
-                              <code>{{ dep.name }}</code>
-                            </v-list-item-title>
-                            <v-list-item-subtitle>{{ dep.version }}</v-list-item-subtitle>
-                          </v-list-item>
-                        </div>
-                      </v-list>
-                    </v-expansion-panel-text>
-                  </v-expansion-panel>
+          <template #item.type="{ item }">
+            <v-chip
+              :color="chipColor(item.typeKey)"
+              size="small"
+              variant="tonal"
+              class="dep-mono dep-chip">
+              {{ item.type }}
+            </v-chip>
+          </template>
 
-                  <v-expansion-panel>
-                    <v-expansion-panel-title>
-                      <div class="d-flex align-center">
-                        <v-icon class="mr-2" color="info">mdi-tools</v-icon>
-                        <strong>Dev Dependencies ({{ componentsDevDeps.length }})</strong>
-                      </div>
-                    </v-expansion-panel-title>
-                    <v-expansion-panel-text>
-                      <div style="max-height: 60vh; overflow-y: auto">
-                        <v-list density="compact">
-                          <v-list-item
-                            v-for="dep in componentsDevDeps"
-                            :key="dep.name"
-                            class="dependency-item">
-                            <template v-slot:prepend>
-                              <v-icon size="small">mdi-circle-small</v-icon>
-                            </template>
-                            <v-list-item-title>
-                              <code>{{ dep.name }}</code>
-                            </v-list-item-title>
-                            <v-list-item-subtitle>{{ dep.version }}</v-list-item-subtitle>
-                          </v-list-item>
-                        </v-list>
-                      </div>
-                    </v-expansion-panel-text>
-                  </v-expansion-panel>
-
-                  <v-expansion-panel>
-                    <v-expansion-panel-title>
-                      <div class="d-flex align-center">
-                        <v-icon class="mr-2" color="warning">mdi-link-variant</v-icon>
-                        <strong>Peer Dependencies ({{ componentsPeerDeps.length }})</strong>
-                      </div>
-                    </v-expansion-panel-title>
-                    <v-expansion-panel-text>
-                      <v-list density="compact">
-                        <v-list-item
-                          v-for="dep in componentsPeerDeps"
-                          :key="dep.name"
-                          class="dependency-item">
-                          <template v-slot:prepend>
-                            <v-icon size="small">mdi-circle-small</v-icon>
-                          </template>
-                          <v-list-item-title>
-                            <code>{{ dep.name }}</code>
-                          </v-list-item-title>
-                          <v-list-item-subtitle>{{ dep.version }}</v-list-item-subtitle>
-                        </v-list-item>
-                      </v-list>
-                    </v-expansion-panel-text>
-                  </v-expansion-panel>
-                </v-expansion-panels>
-              </v-card-text>
-            </v-tabs-window-item>
-
-            <!-- Rust Dependencies -->
-            <v-tabs-window-item value="backend">
-              <v-card-text>
-                <h2 class="text-h5 mb-4">Lakekeeper Backend (Rust)</h2>
-
-                <v-expansion-panels>
-                  <v-expansion-panel>
-                    <v-expansion-panel-title>
-                      <div class="d-flex align-center">
-                        <v-icon class="mr-2" color="error">mdi-language-rust</v-icon>
-                        <strong>Workspace Dependencies ({{ rustDeps.length }})</strong>
-                      </div>
-                    </v-expansion-panel-title>
-                    <v-expansion-panel-text>
-                      <v-text-field
-                        v-model="rustSearch"
-                        label="Search dependencies"
-                        prepend-inner-icon="mdi-magnify"
-                        clearable
-                        density="compact"
-                        class="mb-4"></v-text-field>
-                      <div style="max-height: 60vh; overflow-y: auto">
-                        <v-list density="compact">
-                          <v-list-item
-                            v-for="dep in filteredRustDeps"
-                            :key="dep.name"
-                            class="dependency-item">
-                            <template v-slot:prepend>
-                              <v-icon size="small">mdi-circle-small</v-icon>
-                            </template>
-                            <v-list-item-title>
-                              <code>{{ dep.name }}</code>
-                            </v-list-item-title>
-                            <v-list-item-subtitle>
-                              {{ dep.version }}
-                              <span v-if="dep.features" class="text-caption ml-2">
-                                (features: {{ dep.features }})
-                              </span>
-                            </v-list-item-subtitle>
-                          </v-list-item>
-                        </v-list>
-                      </div>
-                    </v-expansion-panel-text>
-                  </v-expansion-panel>
-                </v-expansion-panels>
-              </v-card-text>
-            </v-tabs-window-item>
-          </v-tabs-window>
-        </v-card>
-      </v-col>
-    </v-row>
-  </v-container>
+          <template #no-data>
+            <div class="deps-empty">No dependencies match your filters.</div>
+          </template>
+        </v-data-table-virtual>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from 'vue';
+import { ref, computed } from 'vue';
 import dependenciesData from '../assets/dependencies.json' with { type: 'json' };
-import { useRoute, useRouter } from 'vue-router';
 
-interface RustDep {
+interface DepEntry {
   name: string;
   version: string;
   features?: string;
 }
 
-const route = useRoute();
-const router = useRouter();
+interface Row {
+  rowKey: string;
+  name: string;
+  version: string;
+  fullVersion: string;
+  source: string;
+  sourceKey: string;
+  type: string;
+  typeKey: string;
+  features?: string;
+}
 
-const tab = ref('console');
-const rustSearch = ref('');
+// Data-driven group config: order + labels. Only groups present in the JSON render.
+const JS_GROUPS = [
+  { key: 'console', label: 'Console' },
+  { key: 'components', label: 'Console components' },
+  { key: 'consolePlusComponents', label: 'Console+ components' },
+  { key: 'consolePlus', label: 'Console+' },
+];
+const RUST_GROUPS = [
+  { key: 'rust', label: 'Lakekeeper (Rust)' },
+  { key: 'rustPlus', label: 'Lakekeeper+ (Rust)' },
+];
+const JS_TYPES = [
+  { arr: 'dependencies', type: 'Runtime', typeKey: 'runtime' },
+  { arr: 'devDependencies', type: 'Dev', typeKey: 'dev' },
+  { arr: 'peerDependencies', type: 'Peer', typeKey: 'peer' },
+];
 
-// Extract dependencies from imported JSON
-const consoleDeps = dependenciesData.console.dependencies;
-const consoleDevDeps = dependenciesData.console.devDependencies;
-const componentsDeps = dependenciesData.components.dependencies;
-const componentsDevDeps = dependenciesData.components.devDependencies;
-const componentsPeerDeps = dependenciesData.components.peerDependencies;
-const rustDeps = dependenciesData.rust.dependencies as RustDep[];
+const data = dependenciesData as Record<string, any>;
 
-const filteredRustDeps = computed(() => {
-  if (!rustSearch.value) return rustDeps;
-  const search = rustSearch.value.toLowerCase();
-  return rustDeps.filter((dep) => dep.name.toLowerCase().includes(search));
-});
+const presentGroups = [...JS_GROUPS, ...RUST_GROUPS].filter((g) => data[g.key]);
 
-onMounted(() => {
-  if (route.query.tab) {
-    tab.value = route.query.tab as string;
+// Flatten every dependency into a single row list.
+const allRows: Row[] = [];
+for (const g of JS_GROUPS) {
+  const group = data[g.key];
+  if (!group) continue;
+  for (const t of JS_TYPES) {
+    const list: DepEntry[] = group[t.arr] || [];
+    for (const dep of list) {
+      allRows.push({
+        rowKey: `${g.key}:${t.typeKey}:${dep.name}`,
+        name: dep.name,
+        version: dep.version,
+        fullVersion: dep.version,
+        source: g.label,
+        sourceKey: g.key,
+        type: t.type,
+        typeKey: t.typeKey,
+      });
+    }
   }
+}
+for (const g of RUST_GROUPS) {
+  const group = data[g.key];
+  if (!group) continue;
+  const list: DepEntry[] = group.dependencies || [];
+  for (const dep of list) {
+    allRows.push({
+      rowKey: `${g.key}:workspace:${dep.name}`,
+      name: dep.name,
+      version: dep.version,
+      fullVersion: dep.version,
+      source: g.label,
+      sourceKey: g.key,
+      type: 'Workspace',
+      typeKey: 'workspace',
+      features: dep.features || undefined,
+    });
+  }
+}
+
+const headers = [
+  { title: 'Package', key: 'name', width: '45%' },
+  { title: 'Version', key: 'version', width: '20%' },
+  { title: 'Source', key: 'source', width: '22%' },
+  { title: 'Type', key: 'type', width: '13%' },
+] as const;
+
+const selectedSource = ref<string>('all');
+const search = ref('');
+
+const selectItems = computed(() => [
+  { title: `All packages (${allRows.length})`, value: 'all' },
+  ...presentGroups.map((g) => ({ title: g.label, value: g.key })),
+]);
+
+// Dropdown filters rows by sourceKey *before* the table; the search box drives
+// the table's own :search.
+const filteredItems = computed(() =>
+  selectedSource.value === 'all'
+    ? allRows
+    : allRows.filter((r) => r.sourceKey === selectedSource.value),
+);
+
+// Mirror the table's built-in search (substring across the visible column keys)
+// so the "X of Y" count reflects what the table actually shows.
+const visibleCount = computed(() => {
+  const q = search.value?.trim().toLowerCase();
+  if (!q) return filteredItems.value.length;
+  return filteredItems.value.filter((r) =>
+    [r.name, r.version, r.source, r.type].some((v) => v.toLowerCase().includes(q)),
+  ).length;
 });
 
-watch(tab, (newTab) => {
-  router.replace({ query: { ...route.query, tab: newTab } });
-});
+const CHIP_COLORS: Record<string, string> = {
+  runtime: 'success',
+  dev: 'info',
+  peer: 'warning',
+  workspace: 'error',
+};
+function chipColor(typeKey: string): string {
+  return CHIP_COLORS[typeKey] ?? 'info';
+}
+
+// npm allows long git/URL specs that would blow out the cell — shorten for display.
+function shortVersion(v: string): string {
+  if (!v) return '';
+  const hash = v.indexOf('#');
+  if (hash !== -1) return v.slice(hash + 1).replace(/^semver:/, '') || 'git';
+  if (/^(github:|git[+@]|https?:\/\/)/.test(v)) {
+    const m = v.match(/v?\d+\.\d+\.\d+[\w.-]*/);
+    return m ? m[0] : 'git';
+  }
+  return v;
+}
 </script>
 
 <style scoped>
-.dependency-item {
-  border-left: 2px solid rgba(0, 0, 0, 0.05);
+.deps-page {
+  --dep-mono: 'JetBrains Mono', ui-monospace, 'Roboto Mono', SFMono-Regular, Menlo, monospace;
+  font-family: 'Inter', 'Roboto', sans-serif;
+  background-color: rgb(var(--v-theme-background));
+  min-height: 100%;
+  padding: 40px 24px 64px;
 }
 
-code {
-  background-color: rgba(0, 0, 0, 0.05);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 0.875rem;
+.deps-inner {
+  max-width: 1120px;
+  margin: 0 auto;
+}
+
+/* Hero */
+.deps-eyebrow {
+  font-family: var(--dep-mono);
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.72rem;
+  font-weight: 500;
+  color: rgb(var(--v-theme-primary));
+  margin: 0 0 6px;
+}
+
+.deps-title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: rgb(var(--v-theme-on-surface));
+  margin: 0;
+}
+
+/* Controls */
+.deps-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin: 28px 0 20px;
+}
+
+.deps-select {
+  flex: 0 1 280px;
+  max-width: 280px;
+}
+
+.deps-search {
+  flex: 1 1 320px;
+  min-width: 220px;
+}
+
+.deps-count {
+  margin: 0 0 0 auto;
+  font-family: var(--dep-mono);
+  font-size: 0.8rem;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+  white-space: nowrap;
+}
+
+/* Table shell */
+.deps-table-wrap {
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+  border-radius: 14px;
+  overflow: hidden;
+  background-color: rgb(var(--v-theme-surface-light));
+}
+
+.deps-table {
+  background-color: transparent;
+}
+
+/* Solid header so virtualized rows don't bleed through while scrolling. */
+.deps-table :deep(thead th) {
+  background-color: rgb(var(--v-theme-surface-light)) !important;
+  font-family: var(--dep-mono) !important;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem !important;
+  font-weight: 600;
+  color: rgba(var(--v-theme-on-surface), 0.6) !important;
+}
+
+/* Cells */
+.dep-mono {
+  font-family: var(--dep-mono);
+}
+
+.dep-name {
+  font-size: 0.85rem;
+  color: rgb(var(--v-theme-on-surface));
+  background: transparent;
+  padding: 0;
+}
+
+.dep-version {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.25;
+}
+
+.dep-version-text {
+  font-size: 0.8rem;
+  color: rgba(var(--v-theme-on-surface), 0.9);
+}
+
+.dep-features {
+  font-size: 0.68rem;
+  color: rgba(var(--v-theme-on-surface), 0.5);
+  margin-top: 2px;
+}
+
+.dep-chip {
+  font-size: 0.64rem !important;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.deps-empty {
+  padding: 48px 16px;
+  text-align: center;
+  color: rgba(var(--v-theme-on-surface), 0.6);
+}
+
+/* Responsive: stack controls full-width on narrow viewports. */
+@media (max-width: 640px) {
+  .deps-controls {
+    gap: 12px;
+  }
+  .deps-select,
+  .deps-search {
+    flex: 1 1 100%;
+    max-width: 100%;
+  }
+  .deps-count {
+    margin-left: 0;
+  }
 }
 </style>


### PR DESCRIPTION
## What
Redesigns the existing **Dependencies** page (`/dependencies`) — same feature, new visual.

- Single data-driven, filterable **`v-data-table-virtual`** replacing the tabbed expansion panels.
- Hero (mono "Transparency" eyebrow + `Dependencies` h1), a **Package** dropdown, a clearable search, and a mono **X of Y** count.
- Rows flattened from `dependencies.json` (Runtime/Dev/Peer for JS, Workspace for Rust) with a colored type chip and a version shortener for long git/URL specs.
- Data-driven: only groups present in the JSON render, so new packages appear with no template edits.
- Theme tokens only (`rgb(var(--v-theme-*))`, no hex); solid fixed header so virtual rows don't bleed through.

## Notes
- No functional change and no dependency changes — visual/refactor only, hence `chore`.
- `vue-tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced the tabbed dependency view with a unified, virtualized table.
  * Added columns for package, version, source, and dependency type.
  * Added global search and source filtering.
  * Added visible and total dependency counts.
  * Added type labels, optional feature details, shortened version display, and empty-state messaging.
  * Improved responsive layout for dependency browsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->