### PR TITLE
feat: forward-port No-Access page and 403 routing to main

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,7 +46,7 @@ branch names (they move) or raw SHAs (redundant with the tag).
 
 | Version | lakekeeper                                                               | console                                                               | console-components                                                               |
 | ------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| 0.13.1  | [v0.13.1](https://github.com/lakekeeper/lakekeeper/releases/tag/v0.13.1) | [v0.21.1](https://github.com/lakekeeper/console/releases/tag/v0.21.1) | [v0.17.1](https://github.com/lakekeeper/console-components/releases/tag/v0.17.1) |
+| 0.13.1  | [v0.13.1](https://github.com/lakekeeper/lakekeeper/releases/tag/v0.13.1) | [v0.21.2](https://github.com/lakekeeper/console/releases/tag/v0.21.2) | [v0.17.3](https://github.com/lakekeeper/console-components/releases/tag/v0.17.3) |
 
 ## Why the OpenAPI spec makes this necessary
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@fontsource/roboto": "^5.2.10",
         "@formbricks/js": "^4.4.0",
-        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.17.1",
+        "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.17.3",
         "@mdi/font": "7.4.47",
         "json-bigint": "^1.0.0",
         "oidc-client-ts": "^3.3.0",
@@ -310,56 +310,11 @@
         "arrow2csv": "bin/arrow2csv.cjs"
       }
     },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "array-back": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/@duckdb/duckdb-wasm/node_modules/flatbuffers": {
       "version": "24.12.23",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
       "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@duckdb/duckdb-wasm/node_modules/typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/@duckdb/duckdb-wasm/node_modules/undici-types": {
       "version": "6.21.0",
@@ -399,9 +354,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -741,8 +696,8 @@
       "license": "MIT"
     },
     "node_modules/@lakekeeper/console-components": {
-      "version": "0.17.1",
-      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#ef41b88f702cb4a47c05699c6c2ae74954ec7918",
+      "version": "0.17.3",
+      "resolved": "git+ssh://git@github.com/lakekeeper/console-components.git#769547a4fa18f819058f7588772d15ae68a9ee2d",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.3",
@@ -1212,23 +1167,24 @@
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
-      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/type-utils": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1241,7 +1197,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.64.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1257,16 +1213,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
-      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1282,14 +1238,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
-      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.64.0",
-        "@typescript-eslint/types": "^8.64.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1304,14 +1260,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
-      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1322,9 +1278,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
-      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1339,15 +1295,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
-      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1364,9 +1320,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
-      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1378,16 +1334,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
-      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.64.0",
-        "@typescript-eslint/tsconfig-utils": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1406,16 +1362,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
-      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1430,13 +1386,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
-      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1659,9 +1615,9 @@
       }
     },
     "node_modules/@vue/language-core": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.7.tgz",
-      "integrity": "sha512-LzmkKinXAMMoh8Jfi/jMUSDUjuPdv8mynH5WJGKfXyZtDw3hQ6GBaoI6Bcnl/Xqlu32q/0Z6i/trp4VXykzyLw==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.8.tgz",
+      "integrity": "sha512-ieGT8jJdhhy0mGzStZhsg/qPw5bQZJg5yF+3+XU6saf4sM7yo9ZXy3h+nCwrm2+b4qS/SypkNdR2jAF3uei9tA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1853,24 +1809,34 @@
       }
     },
     "node_modules/apache-arrow": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
-      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.2.0.tgz",
+      "integrity": "sha512-Hxe6Agq26gQOM954qpzYSllJBPJl+e16U5CkfuMUhLrNba+5nKkttIVlflaovN6oaTratqMGAO8H5u/aNhmHWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@swc/helpers": "^0.5.11",
-        "@types/command-line-args": "^5.2.3",
-        "@types/command-line-usage": "^5.0.4",
-        "@types/node": "^24.0.3",
-        "command-line-args": "^6.0.1",
-        "command-line-usage": "^7.0.1",
+        "@types/node": "^25.2.0",
         "flatbuffers": "^25.1.24",
-        "json-bignum": "^0.0.3",
+        "json-with-bigint": "^3.5.3",
         "tslib": "^2.6.2"
       },
       "bin": {
         "arrow2csv": "bin/arrow2csv.js"
       }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1879,12 +1845,12 @@
       "license": "Python-2.0"
     },
     "node_modules/array-back": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
-      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.17"
+        "node": ">=6"
       }
     },
     "node_modules/ast-kit": {
@@ -1964,16 +1930,16 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -2092,26 +2058,18 @@
       "license": "MIT"
     },
     "node_modules/command-line-args": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
-      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "license": "MIT",
       "dependencies": {
-        "array-back": "^6.2.3",
-        "find-replace": "^5.0.2",
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
         "lodash.camelcase": "^4.3.0",
-        "typical": "^7.3.0"
+        "typical": "^4.0.0"
       },
       "engines": {
-        "node": ">=12.20"
-      },
-      "peerDependencies": {
-        "@75lb/nature": "latest"
-      },
-      "peerDependenciesMeta": {
-        "@75lb/nature": {
-          "optional": true
-        }
+        "node": ">=4.0.0"
       }
     },
     "node_modules/command-line-usage": {
@@ -2127,6 +2085,24 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/commander": {
@@ -3122,20 +3098,15 @@
       }
     },
     "node_modules/find-replace": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
-      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
       "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@75lb/nature": "latest"
-      },
-      "peerDependenciesMeta": {
-        "@75lb/nature": {
-          "optional": true
-        }
+        "node": ">=4.0.0"
       }
     },
     "node_modules/find-up": {
@@ -3176,9 +3147,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -3468,6 +3439,12 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.10.tgz",
+      "integrity": "sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==",
       "license": "MIT"
     },
     "node_modules/json5": {
@@ -4264,9 +4241,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4316,9 +4293,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.9.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.5.tgz",
-      "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4721,6 +4698,15 @@
         "node": ">=12.17"
       }
     },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -4843,16 +4829,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.64.0.tgz",
-      "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.64.0",
-        "@typescript-eslint/parser": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4867,12 +4853,12 @@
       }
     },
     "node_modules/typical": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
-      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.17"
+        "node": ">=8"
       }
     },
     "node_modules/ua-parser-js": {
@@ -4912,6 +4898,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unimport": {
@@ -5662,14 +5649,14 @@
       }
     },
     "node_modules/vue-tsc": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.7.tgz",
-      "integrity": "sha512-+C+rgD49wAQ5bUTl2sp5a8Bzg4YoldMNXM+g7CFe604MYcQ8PrZPMQhIjJSzKXtPBCa+C5ayMipqjbA7splekQ==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.8.tgz",
+      "integrity": "sha512-xXmYlVQpcwJDWyGlqbHrGVOl1h3UOsASymRibrHc+iy9j/UNnOrOn4u+fntHz4D6Cs74RtapeqVV6CzJeg+UlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@volar/typescript": "2.4.28",
-        "@vue/language-core": "3.3.7"
+        "@vue/language-core": "3.3.8"
       },
       "bin": {
         "vue-tsc": "bin/vue-tsc.js"
@@ -5679,9 +5666,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.12.10",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.12.10.tgz",
-      "integrity": "sha512-6u/sWsIoUqWap3FxaIXZ/JObN/E2Z/BWAaliHh3GEl3Ik162zkpcIFYYLTnQiJ8PcyvMSFr+Lzyz7VoERob7JA==",
+      "version": "3.12.11",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.12.11.tgz",
+      "integrity": "sha512-0qAGQcTbPGv9FN/Yr7kq20UV6djAC0oh2+2BPzZ5Zu8Pw/grNnrKLm3I3/6ZtGF+5IAH6FRGjDw8BZItPjJojw==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@fontsource/roboto": "^5.2.10",
     "@formbricks/js": "^4.4.0",
-    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.17.1",
+    "@lakekeeper/console-components": "github:lakekeeper/console-components#v0.17.3",
     "@mdi/font": "7.4.47",
     "json-bigint": "^1.0.0",
     "oidc-client-ts": "^3.3.0",

--- a/src/assets/dependencies.json
+++ b/src/assets/dependencies.json
@@ -12,7 +12,7 @@
       },
       {
         "name": "@lakekeeper/console-components",
-        "version": "github:lakekeeper/console-components#v0.17.1"
+        "version": "github:lakekeeper/console-components#v0.17.3"
       },
       {
         "name": "@mdi/font",
@@ -147,7 +147,7 @@
     ]
   },
   "components": {
-    "version": "0.17.1",
+    "version": "0.17.3",
     "dependencies": [
       {
         "name": "@codemirror/commands",
@@ -559,6 +559,11 @@
         "features": ""
       },
       {
+        "name": "hmac",
+        "version": "0.12",
+        "features": ""
+      },
+      {
         "name": "hostname",
         "version": "0.4.0",
         "features": ""
@@ -711,6 +716,11 @@
       {
         "name": "serde_with",
         "version": "^3.4",
+        "features": ""
+      },
+      {
+        "name": "sha1",
+        "version": "0.10",
         "features": ""
       },
       {

--- a/src/pages/no-access.vue
+++ b/src/pages/no-access.vue
@@ -1,0 +1,15 @@
+<template>
+  <v-row>
+    <v-col class="align-self-center">
+      <NoAccessPage />
+    </v-col>
+  </v-row>
+</template>
+
+<script lang="ts" setup>
+import { NoAccessPage } from '@lakekeeper/console-components';
+// Ensure the library stylesheet is present on this route (it isn't imported
+// globally); without it the NoAccessPage's scoped styles — incl. the Tetris
+// board grid — don't apply. Matches the pattern in bootstrap.vue.
+import '@lakekeeper/console-components/style.css';
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -32,7 +32,7 @@ const router = createRouter({
 
 router.afterEach((to: RouteLocationNormalized) => {
   // Don't store these paths as the last visited location to prevent unwanted restoration after login
-  const excludedPaths = ['/server-offline', '/login', '/callback', '/logout'];
+  const excludedPaths = ['/server-offline', '/login', '/callback', '/logout', '/no-access'];
   if (excludedPaths.includes(to.path)) {
     return;
   }
@@ -95,6 +95,12 @@ router.beforeEach(async (to: any, from: any, next: any) => {
     return next('/server-offline');
   }
 
+  // A 403 on /management/v1/info means the user is authenticated but has no access
+  // to this instance at all — route them to the dedicated No-Access page.
+  function isNoInstanceAccess(code: number) {
+    return code === 403 && env.enabledAuthentication && userStorage.isAuthenticated;
+  }
+
   // If authentication is disabled, redirect auth-related paths to home
   if (!env.enabledAuthentication) {
     if (to.path === '/login' || to.path === '/callback' || to.path === '/logout') {
@@ -106,7 +112,10 @@ router.beforeEach(async (to: any, from: any, next: any) => {
   if (
     to.path === '/server-offline' ||
     (env.enabledAuthentication &&
-      (to.path === '/logout' || to.path === '/login' || to.path === '/callback'))
+      (to.path === '/logout' ||
+        to.path === '/login' ||
+        to.path === '/callback' ||
+        to.path === '/no-access'))
   ) {
     // Special case: if navigating TO /server-offline FROM /callback, this might be
     // console-components restoring a previous location during the auth race condition
@@ -151,7 +160,11 @@ router.beforeEach(async (to: any, from: any, next: any) => {
             userStorage.unsetUser();
             return next('/login');
           }
-          // Don't retry other client errors (403, 404, etc.) — server IS online
+          // A 403 means authenticated-but-no-access → dedicated No-Access page.
+          if (isNoInstanceAccess(retryCode)) {
+            return next('/no-access');
+          }
+          // Don't retry other client errors (404, etc.) — server IS online
           if (retryCode >= 400 && retryCode < 500) {
             serverInfo = { bootstrapped: true } as any;
             break;
@@ -200,6 +213,11 @@ router.beforeEach(async (to: any, from: any, next: any) => {
       serverInfo = { bootstrapped: true } as any;
     }
 
+    // A 403 on /info means authenticated-but-no-access → dedicated No-Access page.
+    if (isNoInstanceAccess(errorCode)) {
+      return next('/no-access');
+    }
+
     // If the server responded with a 4xx (e.g. 403 from Cedar policy), it IS online.
     // Assume bootstrapped and fall through to auth/bootstrap checks.
     if (errorCode >= 400 && errorCode < 500) {
@@ -236,7 +254,11 @@ router.beforeEach(async (to: any, from: any, next: any) => {
             userStorage.unsetUser();
             return next('/login');
           }
-          // Don't retry other client errors (403, 404, etc.) — server IS online
+          // A 403 means authenticated-but-no-access → dedicated No-Access page.
+          if (isNoInstanceAccess(retryCode)) {
+            return next('/no-access');
+          }
+          // Don't retry other client errors (404, etc.) — server IS online
           if (retryCode >= 400 && retryCode < 500) {
             serverInfo = { bootstrapped: true } as any;
             break;

--- a/src/typed-router.d.ts
+++ b/src/typed-router.d.ts
@@ -94,6 +94,13 @@ declare module 'vue-router/auto-routes' {
       Record<never, never>,
       | never
     >,
+    '/no-access': RouteRecordInfo<
+      '/no-access',
+      '/no-access',
+      Record<never, never>,
+      Record<never, never>,
+      | never
+    >,
     '/notfound': RouteRecordInfo<
       '/notfound',
       '/notfound',
@@ -258,6 +265,14 @@ declare module 'vue-router/auto-routes' {
     'src/pages/loqe.vue': {
       routes:
         | '/loqe'
+      views:
+        | never
+      pathParamNames:
+        | never
+    }
+    'src/pages/no-access.vue': {
+      routes:
+        | '/no-access'
       views:
         | never
       pathParamNames:


### PR DESCRIPTION
Forward-port of #362 (released on `rel-0-13` as v0.21.2) to `main`.

- `/no-access` page + redirect authenticated 403 on `/management/v1/info`.
- **Stopgap pin**: `@lakekeeper/console-components` → **v0.17.3** (carries `NoAccessPage`; clean bump from main's v0.17.1). Re-pin when main cuts its own console-components release.
- RELEASING.md matrix updated in place for the 0.13.1 line (console v0.21.2, console-components v0.17.3).

No release-workflow changes here (the rel-* enablement was rel-0-13-only). Do not merge the `main` release PR yet — no release on main.

BEGIN_COMMIT_OVERRIDE
feat(ui): add /no-access page and redirect authenticated 403 on /info to it
fix(ui): bump console-components to 0.17.3 (stopgap pin for NoAccessPage until main releases)
END_COMMIT_OVERRIDE

🤖 Generated with [Claude Code](https://claude.com/claude-code)